### PR TITLE
Fix  NaN % in Powdersum in HOTM Menu if API request fails

### DIFF
--- a/render/gemstoneMiningStats.js
+++ b/render/gemstoneMiningStats.js
@@ -5,6 +5,9 @@ import axios from "../../axios"
 import { findCost, findHotmObject } from "../commands/calculate/hotmCalc"
 const NBTTagString = Java.type("net.minecraft.nbt.NBTTagString")
 let powderTotals = {}
+let getPlayerDataSuccess = false
+let checkedHotmInfo = false
+let checkedHotmReset = false
 
 register("itemTooltip", (lore, item) => { // this is so bad 💀
     if(!settings.gemstoneMiningStats || item.getLore() == undefined || item.getLore()[0] == undefined || !item.getLore()[0].startsWith("§o§aYour SkyBlock Profile")) return
@@ -80,6 +83,7 @@ register("gameLoad", () => {
         if(fortunate != undefined)
             constants.data.fortunate = fortunate
         constants.data.save()
+        getPlayerDataSuccess = true
     })
 })
 
@@ -117,7 +121,6 @@ register("itemTooltip", (lore, item) => { // powder put into each perk
         let level = /Level (\d+)/g.exec(item.getLore()[1])[1]
         let hotmObjectToFind = findHotmObject(perk)
         if(hotmObjectToFind == undefined || (hotmObjectToFind.costFormula == undefined && perk != "Fortunate")) return
-
         let powderSum
 
         if(perk == "Fortunate")
@@ -129,3 +132,43 @@ register("itemTooltip", (lore, item) => { // powder put into each perk
         list.set(0, new NBTTagString(item.getLore()[1] + ` §7(§b${addCommas(Math.round(powderSum))} §l${Math.round(powderSum/powderTotals[hotmObjectToFind.powderType]*100)}%§7)💀`)) // this is a perfect solution no cap
     }).start()
 })
+
+register("itemTooltip", (lore, item) => { // powder put into each perk
+    let loreType = item.getLore()[0]?.removeColorCode()
+    if(!settings.showPowderSum || !loreType?.match(/(^Heart|^Reset).*/g) || (checkedHotmInfo && checkedHotmReset) || getPlayerDataSuccess) return
+    let loreItems = item.getLore()
+    if(!loreItems)
+        return
+
+    for(loreItem of loreItems){
+        if(!!loreType?.match(/(^Heart).*/g) && !checkedHotmInfo){
+            if(!loreItem.removeColorCode().match(/(^Mithril|^Gemstone).*/g))
+                continue
+            let loreItemSplit = loreItem.split(' ')
+            let powderType = loreItemSplit[0].removeColorCode().toLowerCase()
+            let add = parseInt(loreItemSplit[2].removeColorCode().replace(',',''))
+            if(!powderTotals[powderType]){
+                powderTotals[powderType] = add
+            } else if(!checkedHotmInfo) {
+                powderTotals[powderType] += add
+            }
+        } else if(!checkedHotmReset){
+            let stripped = loreItem.removeColorCode().replace(/[ \-,]/g,'')
+            if(!stripped.match(/(MithrilPowder$|GemstonePowder$)/g))
+                continue
+            let powderType = stripped.match(/MithrilPowder$/g) ? "mithril" : "gemstone"
+            stripped = stripped.replace(/(MithrilPowder|GemstonePowder)/g,'')
+            let add = parseInt(stripped)
+            if(!powderTotals[powderType]){
+                powderTotals[powderType] = add
+            } else if(!checkedHotmReset) {
+                powderTotals[powderType] += add
+            }
+        }   
+    }
+    if(!!loreType?.match(/(^Heart).*/g))
+        checkedHotmInfo = true
+    else
+        checkedHotmReset = true
+}).setFps(2)
+

--- a/render/gemstoneMiningStats.js
+++ b/render/gemstoneMiningStats.js
@@ -147,11 +147,12 @@ register("itemTooltip", (lore, item) => { // powder put into each perk
             let loreItemSplit = loreItem.split(' ')
             let powderType = loreItemSplit[0].removeColorCode().toLowerCase()
             let add = parseInt(loreItemSplit[2].removeColorCode().replace(',',''))
-            if(!powderTotals[powderType]){
+            
+            if(!powderTotals[powderType])
                 powderTotals[powderType] = add
-            } else if(!checkedHotmInfo) {
+            else if(!checkedHotmInfo) 
                 powderTotals[powderType] += add
-            }
+            
         } else if(!checkedHotmReset){
             let stripped = loreItem.removeColorCode().replace(/[ \-,]/g,'')
             if(!stripped.match(/(MithrilPowder$|GemstonePowder$)/g))
@@ -159,11 +160,12 @@ register("itemTooltip", (lore, item) => { // powder put into each perk
             let powderType = stripped.match(/MithrilPowder$/g) ? "mithril" : "gemstone"
             stripped = stripped.replace(/(MithrilPowder|GemstonePowder)/g,'')
             let add = parseInt(stripped)
-            if(!powderTotals[powderType]){
+
+            if(!powderTotals[powderType])
                 powderTotals[powderType] = add
-            } else if(!checkedHotmReset) {
+            else if(!checkedHotmReset) 
                 powderTotals[powderType] += add
-            }
+            
         }   
     }
     if(!!loreType?.match(/(^Heart).*/g))

--- a/util/helperFunctions.js
+++ b/util/helperFunctions.js
@@ -562,3 +562,13 @@ export function findTick(speed, block)
 
     return ticks
 }
+
+/**
+ * Function to remove the MC color codes from strings, chainable with other string functions
+ * @returns the string without the color code
+ */
+String.prototype.removeColorCode = function() {
+    let regex = /\u00A7[0-9A-FK-OR]/ig;
+    this.replaced = this.replace(regex,'');
+    return this.replaced
+};


### PR DESCRIPTION
If the API request to get the powder amount of the player fails this extracts the powder totals from the HOTM Info & Reset buttons by hovering over them.
There are two ways in which it is a bit scuffed: 
1) If the player hovers over the perks before hovering over the Info & Reset button it can show NaN (if no button was checked before) or the wrong % if only 1 button was checked. This can be fixed by the player by hovering the not checked buttons and reopening the HOTM menu. This is because the code to set the % runs once per opening the HOTM menu
2) If the player opens the HOTM Menu before the API request completes the same NaN or wrong % from 1) can occur since then the buttons get checked for powder. This has the same fix of re-opening the HOTM Menu