### PR TITLE
Fix wrong color code

### DIFF
--- a/render/gemstoneMiningStats.js
+++ b/render/gemstoneMiningStats.js
@@ -107,9 +107,9 @@ register("step", () => {
 
 
 register("itemTooltip", (lore, item) => {
-    if(item.getLore()[0]?.startsWith("§o§eFortunate§r"))
+    if(item.getLore()[0]?.startsWith("§o§aFortunate§r") || item.getLore()[0]?.startsWith("§o§eFortunate§r"))
         constants.data.fortunate = parseInt(item.getLore()[1].replace("§5§o§7Level ", ""))
-    else if (item.getLore()[0]?.startsWith("§o§eProfessional§r"))
+    else if (item.getLore()[0]?.startsWith("§o§aProfessional§r") || item.getLore()[0]?.startsWith("§o§eFortunate§r"))
         constants.data.professional = parseInt(item.getLore()[1].replace("§5§o§7Level ", ""))
     else return
     constants.data.save()

--- a/render/gemstoneMiningStats.js
+++ b/render/gemstoneMiningStats.js
@@ -107,9 +107,9 @@ register("step", () => {
 
 
 register("itemTooltip", (lore, item) => {
-    if(item.getLore()[0]?.startsWith("§o§aFortunate§r"))
+    if(item.getLore()[0]?.startsWith("§o§eFortunate§r"))
         constants.data.fortunate = parseInt(item.getLore()[1].replace("§5§o§7Level ", ""))
-    else if (item.getLore()[0]?.startsWith("§o§aProfessional§r"))
+    else if (item.getLore()[0]?.startsWith("§o§eProfessional§r"))
         constants.data.professional = parseInt(item.getLore()[1].replace("§5§o§7Level ", ""))
     else return
     constants.data.save()

--- a/render/gemstoneMiningStats.js
+++ b/render/gemstoneMiningStats.js
@@ -109,7 +109,7 @@ register("step", () => {
 register("itemTooltip", (lore, item) => {
     if(item.getLore()[0]?.startsWith("§o§aFortunate§r") || item.getLore()[0]?.startsWith("§o§eFortunate§r"))
         constants.data.fortunate = parseInt(item.getLore()[1].replace("§5§o§7Level ", ""))
-    else if (item.getLore()[0]?.startsWith("§o§aProfessional§r") || item.getLore()[0]?.startsWith("§o§eFortunate§r"))
+    else if (item.getLore()[0]?.startsWith("§o§aProfessional§r") || item.getLore()[0]?.startsWith("§o§eProfessional§r"))
         constants.data.professional = parseInt(item.getLore()[1].replace("§5§o§7Level ", ""))
     else return
     constants.data.save()

--- a/render/gemstoneMiningStats.js
+++ b/render/gemstoneMiningStats.js
@@ -107,9 +107,9 @@ register("step", () => {
 
 
 register("itemTooltip", (lore, item) => {
-    if(item.getLore()[0]?.startsWith("§o§aFortunate§r") || item.getLore()[0]?.startsWith("§o§eFortunate§r"))
+    if(item.getLore()[0]?.startsWith("§o§aFortunate§r") || item.getLore()[0]?.startsWith("§o§eFortunate§r") || item.getLore()[0]?.startsWith("§o§cFortunate§r"))
         constants.data.fortunate = parseInt(item.getLore()[1].replace("§5§o§7Level ", ""))
-    else if (item.getLore()[0]?.startsWith("§o§aProfessional§r") || item.getLore()[0]?.startsWith("§o§eProfessional§r"))
+    else if (item.getLore()[0]?.startsWith("§o§aProfessional§r") || item.getLore()[0]?.startsWith("§o§eProfessional§r") || item.getLore()[0]?.startsWith("§o§cProfessional§r"))
         constants.data.professional = parseInt(item.getLore()[1].replace("§5§o§7Level ", ""))
     else return
     constants.data.save()


### PR DESCRIPTION
While debugging a bug that prevented Block Tick from displaying properly, I discovered that the color code validation was wrong.
I did not verify that the Block Tick was calculated correctly, but I did verify that the correct values were stored in constants.data.professional and constants.data.fortunate.

This is working correctly, at least in my environment.

I'm using a translator, so sorry if the text is wrong.